### PR TITLE
Ignore extra fields in DiscoveryRequest that are unknown

### DIFF
--- a/http.go
+++ b/http.go
@@ -146,6 +146,8 @@ func (h *xDSHandler) handleConfig(w http.ResponseWriter, req *http.Request) {
 
 func readDiscoveryRequest(req *http.Request) (*v2.DiscoveryRequest, error) {
 	var dr v2.DiscoveryRequest
-	err := jsonpb.Unmarshal(req.Body, &dr)
+	err := (&jsonpb.Unmarshaler{
+		AllowUnknownFields: true,
+	}).Unmarshal(req.Body, &dr)
 	return &dr, err
 }


### PR DESCRIPTION
Since envoy 1.13+, new fields are being sent to v2 API requests. Instead
of updating protobuf defintions which is causing a bigger change, this
should ignore them since we don't need them anyways.