### PR TITLE
Example of changes required to test out xds config with different envoy version

### DIFF
--- a/example/envoy/Dockerfile
+++ b/example/envoy/Dockerfile
@@ -1,3 +1,3 @@
-FROM envoyproxy/envoy:v1.14.1
+FROM envoyproxy/envoy:v1.11.0
 COPY envoy.yaml /etc/envoy/envoy.yaml
 RUN mkdir -p /run/envoy

--- a/example/k8s/configmap.yaml
+++ b/example/k8s/configmap.yaml
@@ -17,6 +17,17 @@ data:
               '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
               cluster: foo
               stat_prefix: foo
+              access_log:
+              - name: envoy.access_loggers.file
+                filter:
+                  status_code_filter:
+                    comparison:
+                      op: GE
+                      value:
+                        default_value: 500
+                        runtime_key: access_log_50X_errors
+                config:
+                  path: "/var/log/envoy/relay-http.access.log"
     - name: bar
       address:
         socket_address:

--- a/example/runtests.sh
+++ b/example/runtests.sh
@@ -34,7 +34,7 @@ function main {
 
   log "Deploy to k8s"
   kubectl apply -f "${SCRIPT_DIR}/k8s"
-  trap 'kubectl delete -f "${SCRIPT_DIR}/k8s"' exit
+  # trap 'kubectl delete -f "${SCRIPT_DIR}/k8s"' exit
 
   log "Wait a bit ..."
   sleep 5


### PR DESCRIPTION
This PR shows how to validate xDS configuration pulled by different envoy version, in this case, an old `1.11.0`.

Reproduction steps:
- Change the envoy version for the base image in `xdsenvoy` Dockerfile
- Add the config you'd like to test out, in this case, it's access logs filter
- Optionally comment out the cleanup part from `runtests.sh` to check the logs
- `./runtests.sh`

This will result in:

Tests failing for foo listener:

```
[2020-11-19 10:47:54]: Running tests
 ✓ /config_dump contains dynamicly configured foo cluster
 ✗ foo cluster response is from foo server
   (in test file tests/envoy.bats, line 14)
     `curl -f -s "${ENVOY_FOO_URL}" | grep "Server name: foo-"' failed
 ✓ /heatlhz endpoint is ok
 ✓ /config endpoint reports no error
 ✓ /v2/discovery:clusters select foo
 ✓ /v2/discovery:clusters select bar
 ✓ /v2/discovery:clusters select baz
 ✓ /v2/discovery:clusters select qux
 ✓ /v2/discovery:listeners select foo
 ✓ /v2/discovery:listeners select bar
 ✓ /v2/discovery:listeners select qux
 ✓ /v2/discovery:endpoints select foo
 ✓ /v2/discovery:endpoints select bar
 ✓ /v2/discovery:endpoints select qux
 ✓ /validate endpoint invalid configmap
 ✓ /validate endpoint valid configmap
 ✓ --validate from stdin invalid
 ✓ --validate from stdin valid
 ✓ --validate file invalid
 ✓ --validate file valid

20 tests, 1 failure
```

With a message in logs:

```
[2020-11-19 09:47:50.446][1][warning][config] [source/common/config/http_subscription_impl.cc:88] REST config update rejected: Error adding/updating listener(s) foo: Didn't find a registered implementation for name: 'envoy.access_loggers.file'
```


