### PR TITLE
feat: enable v3 extensions

### DIFF
--- a/example/k8s/configmap.yaml
+++ b/example/k8s/configmap.yaml
@@ -14,7 +14,7 @@ data:
         - filters:
           - name: envoy.tcp_proxy
             typed_config:
-              '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+              '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
               cluster: foo
               stat_prefix: foo
     - name: bar

--- a/example/k8s/configmap.yaml
+++ b/example/k8s/configmap.yaml
@@ -17,6 +17,14 @@ data:
               '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
               cluster: foo
               stat_prefix: foo
+          - name: envoy.filters.http.health_check
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+              pass_through_mode: true
+              cache_time: 1s
+              headers:
+              - name: :path
+                exact_match: /health/
     - name: bar
       address:
         socket_address:

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
-	google.golang.org/protobuf v1.23.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.0.0-20181121071145-b7bd5f2d334c
 	k8s.io/apimachinery v0.0.0-20181126122622-195a1699ff5c

--- a/main.go
+++ b/main.go
@@ -12,6 +12,11 @@ import (
 	"path"
 	"path/filepath"
 
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_proxy/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/ratelimit/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/redis_proxy/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+
 	_ "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	_ "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/rate_limit/v2"
 	_ "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/redis_proxy/v2"

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/ratelimit/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/redis_proxy/v3"

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/redis_proxy/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 
+	_ "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/health_check/v2"
 	_ "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	_ "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/rate_limit/v2"
 	_ "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/redis_proxy/v2"

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"path"
 	"path/filepath"
 
-	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_proxy/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/ratelimit/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/redis_proxy/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"


### PR DESCRIPTION
This enables a few v3 extensions which can now be utilized inside the v2 protos. I've validated and tested so far only via moving a v2.TcpProxy to a v3.TcpProxy on Envoy 1.16.0, but everything behaves correctly.