### PR TITLE
Keep working Config in case of failed update

### DIFF
--- a/configstore.go
+++ b/configstore.go
@@ -187,8 +187,11 @@ func (cs *ConfigStore) Load(cm *v1.ConfigMap) error {
 	defer func() {
 		cs.lastUpdate = time.Now()
 	}()
+	configSnapshot := cs.config
 	cs.config = NewConfig()
 	if err := cs.config.Load(cm); err != nil {
+		// Restore previously loaded Config
+		cs.config = configSnapshot
 		return err
 	}
 	cs.configMap = cm


### PR DESCRIPTION
In cases when updated ConfigMap contains some errors (for example, numbers for Duration fields), the update will fail with an error like:

```
configstore.go:231: update failed:  listeners: index 0: can't unmarshal Any nested proto type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager: json: cannot unmarshal number into Go value of type string: <<LISTENER CONFIG FOLLOWS>>
```
and `cs.config` won't be set. Because `cs.config` contains empty/null values, this leads to null pointer dereferences in client HTTP requests:

```
server.go:3095: http: panic serving xxx.xxx.xxx.xxx:30788: runtime error: invalid memory address or nil pointer dereference
goroutine 403455 [running]:
net/http.(*conn).serve.func1(0xc0004d2820)
	/usr/local/go/src/net/http/server.go:1801 +0x147
panic(0x153ae20, 0x23a9960)
	/usr/local/go/src/runtime/panic.go:975 +0x47a
main.(*Config).getAssignmentCache(...)
	/usr/src/app/configstore.go:103
main.(*Config).GetClusters(...)
	/usr/src/app/configstore.go:118
main.(*xDSHandler).handleCDS(0xc000506800, 0x194f2e0, 0xc0007a2540, 0xc000a9a600)
	/usr/src/app/http.go:147 +0xfb
main.(*xDSHandler).ServeHTTP(0xc000506800, 0x194f2e0, 0xc0007a2540, 0xc000a9a600)
	/usr/src/app/http.go:28 +0x2fc
net/http.serverHandler.ServeHTTP(0xc0001c4000, 0x194f2e0, 0xc0007a2540, 0xc000a9a600)
	/usr/local/go/src/net/http/server.go:2843 +0xa3
net/http.(*conn).serve(0xc0004d2820, 0x1950be0, 0xc000994800)
	/usr/local/go/src/net/http/server.go:1925 +0x8ad
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2969 +0x36c
```

This PR adds some error protection: in such cases, we ignore the invalid update and restore the previously working Config.